### PR TITLE
Float Modulo support

### DIFF
--- a/src/vm.cs
+++ b/src/vm.cs
@@ -2045,7 +2045,7 @@ public class VM
         curr_frame.stack.Push(Val.NewNum(this, (int)l_operand._num | (int)r_operand._num));
       break;
       case Opcodes.Mod:
-        curr_frame.stack.Push(Val.NewNum(this, (int)l_operand._num % (int)r_operand._num));
+        curr_frame.stack.Push(Val.NewNum(this, l_operand._num % r_operand._num));
       break;
     }
 

--- a/tests/test_vm.cs
+++ b/tests/test_vm.cs
@@ -1592,6 +1592,43 @@ public class BHL_TestVM : BHL_TestBase
     AssertEqual(fb.result.PopRelease().num, 1);
     CommonChecks(vm);
   }
+  
+  [IsTested()]
+  public void TestModDouble()
+  {
+    string bhl = @"
+    func float test()
+    {
+      return 2.7 % 2
+    }
+    ";
+
+    var c = Compile(bhl);
+
+
+    var expected =
+      new ModuleCompiler()
+      .UseInit()
+      .EmitThen(Opcodes.Func, new int[] { ConstIdx(c, "test"), 0 })
+      .UseCode()
+      .EmitThen(Opcodes.InitFrame, new int[] { 1 /*args info*/})
+      .EmitThen(Opcodes.Constant, new int[] { ConstIdx(c, 2.7) })
+      .EmitThen(Opcodes.Constant, new int[] { ConstIdx(c, 2) })
+      .EmitThen(Opcodes.Mod)
+      .EmitThen(Opcodes.ReturnVal, new int[] { 1 })
+      .EmitThen(Opcodes.Return)
+      ;
+    AssertEqual(c, expected);
+
+    AssertEqual(c.Constants.Count, 3);
+
+    var vm = MakeVM(c);
+    var fb = vm.Start("test");
+    AssertFalse(vm.Tick());
+    double expectedNum = 2.7 % 2;
+    AssertEqual(fb.result.PopRelease().num, expectedNum);
+    CommonChecks(vm);
+  }
 
   [IsTested()]
   public void TestEmptyParenExpression()


### PR DESCRIPTION
Added modulo support for floating point numbers.
before: 2.7 % 2 = 0
after: 2.7 % 2 = 0.7