### PR TITLE
Add "Contains" method to arrays

### DIFF
--- a/src/vm/symbol.cs
+++ b/src/vm/symbol.cs
@@ -722,6 +722,13 @@ public abstract class ArrayTypeSymbol : ClassSymbol
     }
 
     {
+      var fn = new FuncSymbolNative("Contains", Types.Bool, Contains,
+        new FuncArgSymbol("o", item_type)
+      );
+      this.Define(fn);
+    }
+
+    {
       //hidden system method not available directly
       FuncArrIdx = new FuncSymbolNative("$ArrIdx", item_type, ArrIdx);
     }
@@ -745,6 +752,7 @@ public abstract class ArrayTypeSymbol : ClassSymbol
   public abstract Coroutine ArrIdxW(VM.Frame frame, ValStack stack, FuncArgsInfo args_info, ref BHS status);
   public abstract Coroutine RemoveAt(VM.Frame frame, ValStack stack, FuncArgsInfo args_info, ref BHS status);
   public abstract Coroutine IndexOf(VM.Frame frame, ValStack stack, FuncArgsInfo args_info, ref BHS status);
+  public abstract Coroutine Contains(VM.Frame frame, ValStack stack, FuncArgsInfo args_info, ref BHS status);
   public abstract Coroutine Clear(VM.Frame frame, ValStack stack, FuncArgsInfo args_info, ref BHS status);
 }
 
@@ -810,6 +818,28 @@ public class GenericArrayTypeSymbol : ArrayTypeSymbol, IEquatable<GenericArrayTy
     val.Release();
     arr.Release();
     stack.Push(Val.NewInt(frm.vm, idx));
+    return null;
+  }
+  
+  public override Coroutine Contains(VM.Frame frm, ValStack stack, FuncArgsInfo args_info, ref BHS status)
+  {
+    var val = stack.Pop();
+    var arr = stack.Pop();
+    var lst = AsList(arr);
+
+    bool contains = false;
+    for(int i=0;i<lst.Count;++i)
+    {
+      if(lst[i].IsValueEqual(val))
+      {
+        contains = true;
+        break;
+      }
+    }
+
+    val.Release();
+    arr.Release();
+    stack.Push(Val.NewBool(frm.vm, contains));
     return null;
   }
 
@@ -937,6 +967,18 @@ public class ArrayTypeSymbolT<T> : ArrayTypeSymbol where T : new()
     val.Release();
     arr.Release();
     stack.Push(Val.NewInt(frm.vm, idx));
+    return null;
+  }
+  
+  public override Coroutine Contains(VM.Frame frm, ValStack stack, FuncArgsInfo args_info, ref BHS status)
+  {
+    var val = stack.Pop();
+    var arr = stack.Pop();
+    var lst = (IList<T>)arr.obj;
+    bool contains = lst.Contains((T)val.obj);
+    val.Release();
+    arr.Release();
+    stack.Push(Val.NewBool(frm.vm, contains));
     return null;
   }
 

--- a/src/vm/vm.cs
+++ b/src/vm/vm.cs
@@ -2197,7 +2197,7 @@ public class VM : INamedResolver
     if(cast_type == Types.Int)
       new_val.SetNum((long)val.num);
     else if(cast_type == Types.String && val.type != Types.String)
-      new_val.SetStr(val.num.ToString());
+      new_val.SetStr(val.num.ToString(System.Globalization.CultureInfo.InvariantCulture));
     else
     {
       //TODO: think better about run-time invalid casting error

--- a/tests/test_import.cs
+++ b/tests/test_import.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using bhl;
 
 public class TestImport : BHL_TestBase
@@ -279,10 +280,10 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("collections/unit.bhl", file_unit, ref files);
-    NewTestFile("try/get.bhl", file_get, ref files);
+    NewTestFile("collections" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
+    NewTestFile("try" + Path.DirectorySeparatorChar + "get.bhl", file_get, ref files);
     NewTestFile("test.bhl", file_test, ref files);
-    NewTestFile("use/use.bhl", file_use, ref files);
+    NewTestFile("use" + Path.DirectorySeparatorChar + "use.bhl", file_use, ref files);
 
     {
       var exec = new CompilationExecutor();
@@ -975,8 +976,8 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("unit/unit.bhl", file_unit, ref files);
-    NewTestFile("test/test.bhl", file_test, ref files);
+    NewTestFile("unit" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
+    NewTestFile("test" + Path.DirectorySeparatorChar + "test.bhl", file_test, ref files);
 
     {
       var exec = new CompilationExecutor();
@@ -1015,8 +1016,8 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("units/unit.bhl", file_unit, ref files);
-    NewTestFile("tests/test.bhl", file_test, ref files);
+    NewTestFile("units" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
+    NewTestFile("tests" + Path.DirectorySeparatorChar + "test.bhl", file_test, ref files);
 
     {
       var ts = new Types();

--- a/tests/test_import.cs
+++ b/tests/test_import.cs
@@ -280,10 +280,10 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("collections" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
-    NewTestFile("try" + Path.DirectorySeparatorChar + "get.bhl", file_get, ref files);
+    NewTestFile(Path.Combine("collections", "unit.bhl"), file_unit, ref files);
+    NewTestFile(Path.Combine("try", "get.bhl"), file_get, ref files);
     NewTestFile("test.bhl", file_test, ref files);
-    NewTestFile("use" + Path.DirectorySeparatorChar + "use.bhl", file_use, ref files);
+    NewTestFile(Path.Combine("use", "use.bhl"), file_use, ref files);
 
     {
       var exec = new CompilationExecutor();
@@ -976,8 +976,8 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("unit" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
-    NewTestFile("test" + Path.DirectorySeparatorChar + "test.bhl", file_test, ref files);
+    NewTestFile(Path.Combine("unit", "unit.bhl"), file_unit, ref files);
+    NewTestFile(Path.Combine("test", "test.bhl"), file_test, ref files);
 
     {
       var exec = new CompilationExecutor();
@@ -1016,8 +1016,8 @@ public class TestImport : BHL_TestBase
     CleanTestDir();
 
     var files = new List<string>();
-    NewTestFile("units" + Path.DirectorySeparatorChar + "unit.bhl", file_unit, ref files);
-    NewTestFile("tests" + Path.DirectorySeparatorChar + "test.bhl", file_test, ref files);
+    NewTestFile(Path.Combine("units", "unit.bhl"), file_unit, ref files);
+    NewTestFile(Path.Combine("tests", "test.bhl"), file_test, ref files);
 
     {
       var ts = new Types();

--- a/tests/test_shared.cs
+++ b/tests/test_shared.cs
@@ -677,7 +677,7 @@ public class BHL_TestBase
 
   public static int NewTestFile(string path, string text, ref List<string> files, bool unique = false)
   {
-    string full_path = TestDirPath() + "/" + path;
+    string full_path = TestDirPath() + Path.DirectorySeparatorChar + path;
     if(unique)
       files.Remove(full_path);
     Directory.CreateDirectory(Path.GetDirectoryName(full_path));
@@ -802,7 +802,7 @@ public class BHL_TestBase
   public static string TestDirPath()
   {
     string self_bin = System.Reflection.Assembly.GetExecutingAssembly().Location;
-    return Path.GetDirectoryName(self_bin) + "/tmp/tests";
+    return Path.GetDirectoryName(self_bin) + Path.DirectorySeparatorChar + "tmp"+ Path.DirectorySeparatorChar + "tests";
   }
 
   public static void Assert(bool condition, string msg = null)
@@ -906,9 +906,9 @@ public class BHL_TestBase
       if(err is ICompileError cerr)
       {
         string place_err = ErrorUtils.ShowErrorPlace(place_assert.source, cerr.range);
-        if(place_err.Trim('\n') != place_assert.expect.Trim('\n'))
+        if(place_err.Trim('\r','\n') != place_assert.expect.Trim('\r','\n'))
           Console.WriteLine(err.StackTrace);
-        AssertEqual(place_err.Trim('\n'), place_assert.expect.Trim('\n'));
+        AssertEqual(place_err.Trim('\r','\n'), place_assert.expect.Trim('\r','\n'));
       }
       else
         AssertTrue(false, "No ICompileError occured, got " + err?.GetType().Name); 

--- a/tests/test_shared.cs
+++ b/tests/test_shared.cs
@@ -677,7 +677,7 @@ public class BHL_TestBase
 
   public static int NewTestFile(string path, string text, ref List<string> files, bool unique = false)
   {
-    string full_path = TestDirPath() + Path.DirectorySeparatorChar + path;
+    string full_path = Path.Combine(TestDirPath(), path);
     if(unique)
       files.Remove(full_path);
     Directory.CreateDirectory(Path.GetDirectoryName(full_path));
@@ -802,7 +802,7 @@ public class BHL_TestBase
   public static string TestDirPath()
   {
     string self_bin = System.Reflection.Assembly.GetExecutingAssembly().Location;
-    return Path.GetDirectoryName(self_bin) + Path.DirectorySeparatorChar + "tmp"+ Path.DirectorySeparatorChar + "tests";
+    return Path.Combine(Path.GetDirectoryName(self_bin), "tmp", "tests");
   }
 
   public static void Assert(bool condition, string msg = null)

--- a/tests/test_std.cs
+++ b/tests/test_std.cs
@@ -24,7 +24,7 @@ public class TestStd : BHL_TestBase
     Execute(vm, "test");
     Console.SetOut(std_out);
 
-    AssertEqual("Hello!\n", w.ToString());
+    AssertEqual("Hello!", w.ToString().Trim('\r', '\n'));
     CommonChecks(vm);
   }
 }

--- a/tests/test_vm.cs
+++ b/tests/test_vm.cs
@@ -10130,6 +10130,66 @@ public class TestVM : BHL_TestBase
       CommonChecks(vm);
     }
   }
+  
+  [IsTested()]
+  public void TestArrayContains()
+  {
+    {
+      string bhl = @"
+      func bool test() 
+      {
+        []int arr = [1, 2, 10]
+        return arr.Contains(2)
+      }
+      ";
+
+      var vm = MakeVM(bhl);
+      AssertTrue(true == Execute(vm, "test").result.PopRelease().bval);
+      CommonChecks(vm);
+    }
+
+    {
+      string bhl = @"
+      func bool test() 
+      {
+        []int arr = [1, 2, 10]
+        return arr.Contains(1)
+      }
+      ";
+
+      var vm = MakeVM(bhl);
+      AssertTrue(true == Execute(vm, "test").result.PopRelease().bval);
+      CommonChecks(vm);
+    }
+
+    {
+      string bhl = @"
+      func bool test() 
+      {
+        []int arr = [1, 2, 10]
+        return arr.Contains(10)
+      }
+      ";
+
+      var vm = MakeVM(bhl);
+      AssertTrue(true == Execute(vm, "test").result.PopRelease().bval);
+      CommonChecks(vm);
+    }
+
+    {
+      string bhl = @"
+      func bool test() 
+      {
+        []int arr = [1, 2, 10]
+        return arr.Contains(100)
+      }
+      ";
+
+      var vm = MakeVM(bhl);
+      AssertTrue(false == Execute(vm, "test").result.PopRelease().bval);
+      CommonChecks(vm);
+    }
+  }
 
   [IsTested()]
   public void TestStringArrayAssign()


### PR DESCRIPTION
Suggest to add Contains method to arrays to easily checks if element **contains** in array
```
[]int arr = [1, 2, 10]
return arr.Contains(2) //true
```