### PR TITLE
Avoid excessive allocs in func signature construction

### DIFF
--- a/src/vm/type/func.cs
+++ b/src/vm/type/func.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text;
 using System.Collections.Generic;
 
 namespace bhl {


### PR DESCRIPTION
Reducing GC pressure in func signature construction:
- using `StringBuilder` instead of repeated string concats
- using bitwise And instead of `HasFlag` to check attributes without boxing